### PR TITLE
Reorder Service Page Tabs and Update Server Package Exports

### DIFF
--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/application/[applicationId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/application/[applicationId].tsx
@@ -226,6 +226,7 @@ const Service = (
 											<TabsTrigger value="general">General</TabsTrigger>
 											<TabsTrigger value="environment">Environment</TabsTrigger>
 											<TabsTrigger value="domains">Domains</TabsTrigger>
+											<TabsTrigger value="deployments">Deployments</TabsTrigger>
 											<TabsTrigger value="preview-deployments">
 												Preview Deployments
 											</TabsTrigger>
@@ -233,7 +234,6 @@ const Service = (
 											<TabsTrigger value="volume-backups">
 												Volume Backups
 											</TabsTrigger>
-											<TabsTrigger value="deployments">Deployments</TabsTrigger>
 											<TabsTrigger value="logs">Logs</TabsTrigger>
 											{((data?.serverId && isCloud) || !data?.server) && (
 												<TabsTrigger value="monitoring">Monitoring</TabsTrigger>

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,21 +1,32 @@
 {
   "name": "@dokploy/server",
   "version": "1.0.0",
-  "main": "./src/index.ts",
+  "main": "./dist/index.js",
   "type": "module",
   "exports": {
-    ".": "./src/index.ts",
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs.js"
+    },
     "./db": {
-      "import": "./src/db/index.ts",
+      "import": "./dist/db/index.js",
       "require": "./dist/db/index.cjs.js"
     },
-    "./setup/*": {
-      "import": "./src/setup/*.ts",
-      "require": "./dist/setup/index.cjs.js"
+    "./*": {
+      "import": "./dist/*",
+      "require": "./dist/*.cjs"
     },
-    "./constants": {
-      "import": "./src/constants/index.ts",
-      "require": "./dist/constants.cjs.js"
+    "./dist": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs.js"
+    },
+    "./dist/db": {
+      "import": "./dist/db/index.js",
+      "require": "./dist/db/index.cjs.js"
+    },
+    "./dist/db/schema": {
+      "import": "./dist/db/schema/index.js",
+      "require": "./dist/db/schema/index.cjs.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
## Summary
- Reordered the tabs on the service page for better UX by moving the "Deployments" tab before "Preview Deployments"
- Updated the `@dokploy/server` package exports and main entry points to use the compiled `dist` directory instead of source `src` files

## Changes

### Service Page Tabs
- Moved the "Deployments" tab trigger to appear before "Preview Deployments" in the service application page

### Server Package Configuration
- Changed `main` entry in `package.json` from `./src/index.ts` to `./dist/index.js`
- Updated `exports` field to provide both `import` and `require` paths pointing to compiled files in `dist` folder
- Added additional export mappings for sub-paths under `dist` to support better module resolution

## Test plan
- Verified the tab order change reflects correctly in the UI
- Confirmed the server package builds and exports resolve correctly with the new paths
- Ran existing tests to ensure no regressions in functionality

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/0d01bbe7-a083-43cb-b94f-474d348516a0